### PR TITLE
[codex] Add actions security checks

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,0 +1,36 @@
+name: GitHub Actions Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  actions-security:
+    name: Check workflows
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+        with:
+          aqua_version: v2.56.6
+
+      - name: Check action pinning
+        run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Audit workflows
+        run: zizmor --format github .
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,23 +5,27 @@ on:
     branches:
       - main
 
+
+permissions:
+  contents: read
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
+          persist-credentials: false
           fetch-depth: 0
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: 8
           run_install: true
       - name: move index_bg.wasm
         run: mkdir -p ./src/vendor && cp node_modules/@resvg/resvg-wasm/index_bg.wasm ./src/vendor/index_bg.wasm
       - name: Deploy
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
           packageManager: pnpm
           apiToken: ${{ secrets.CF_API_TOKEN }}
-        
+

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,12 +3,17 @@ name: Lint
 on:
   push:
 
+
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: 8
           run_install: true
@@ -16,8 +21,10 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: 8
           run_install: true

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -12,3 +12,5 @@ registries:
     ref: v4.502.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: evilmartians/lefthook@v2.1.6
+  - name: suzuki-shunsuke/pinact@v4.0.0
+  - name: zizmorcore/zizmor@v1.25.2


### PR DESCRIPTION
## Summary
- Pin GitHub Actions references to commit SHAs with pinact annotations
- Add aqua-managed pinact and zizmor tools
- Add a GitHub Actions Security workflow that installs tools via aqua and runs pinact/zizmor
- Set read-only workflow permissions and disable checkout credential persistence where applicable

## Validation
- actionlint .github/workflows/*.{yml,yaml}
- git diff --check -- .github/workflows aqua.yaml