### PR TITLE
[codex] Migrate Worker types to Wrangler generation

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,3 +27,14 @@ jobs:
         with:
           run_install: true
       - run: pnpm run fmt:check
+  typegen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          run_install: true
+      - run: pnpm run cf-typegen
+      - run: git diff --exit-code -- worker-configuration.d.ts


### PR DESCRIPTION
## Summary

- migrate Worker runtime typing to Wrangler-generated `worker-configuration.d.ts`
- add the Node types required by `nodejs_compat`
- add a CI `typegen` job that runs `wrangler types` and fails if `worker-configuration.d.ts` is stale

## Validation

- `CI=true pnpm run cf-typegen`
- `git diff --exit-code -- worker-configuration.d.ts`
- `actionlint .github/workflows/*.yaml`
- GitHub Actions run `29109446918`
  - `typegen` passed
  - `pnpm run cf-typegen` passed
  - `git diff --exit-code -- worker-configuration.d.ts` passed
