### PR TITLE
Update pnpm to 11.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "qrworker",
 	"version": "0.0.0",
 	"private": true,
-	"packageManager": "pnpm@11.11.0",
+	"packageManager": "pnpm@11.13.0",
 	"scripts": {
 		"deploy": "wrangler deploy",
 		"build": "wrangler deploy --dry-run --outdir dist",


### PR DESCRIPTION
## Summary

- pin `packageManager` to `pnpm@11.13.0`
- keep `package.json` as the single source of truth for the pnpm version
- leave workflows unchanged

## Why

PR #184 fails in `pnpm/action-setup` v6.0.9 while its self-installer switches from pnpm 11.7.0 to 11.12.0. The published pnpm 11.13.0 package restores the structure required by this setup path.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run prepare:wasm`
- `pnpm run lint`
- `pnpm run fmt:check`
- `pnpm exec tsc --noEmit`
- `pnpm run test -- --run`
- `pnpm run cf-typegen`
- `git diff --exit-code -- worker-configuration.d.ts`
- `pnpm run build`
- `pinact run --check`
- `zizmor --format github .`

Re-resolving with pnpm 11.13.0 produced no `pnpm-lock.yaml` changes.
